### PR TITLE
Update with support of cip3 ed25519 bip32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "37.0.0",
+  "version": "37.0.0-cip3",
   "private": true,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@babel/core": "patch:@babel/core@npm%3A7.23.2#./.yarn/patches/@babel-core-npm-7.23.2-b93f586907.patch",
     "@esbuild-plugins/node-modules-polyfill@^0.2.2": "patch:@esbuild-plugins/node-modules-polyfill@npm%3A0.2.2#./.yarn/patches/@esbuild-plugins-node-modules-polyfill-npm-0.2.2-f612681798.patch",
     "@lavamoat/lavapack@^6.1.1": "patch:@lavamoat/lavapack@npm%3A6.1.1#./.yarn/patches/@lavamoat-lavapack-npm-6.1.1-b81af21193.patch",
+    "@metamask/key-tree": "https://github.com/nufi-official/metamask-key-tree/releases/download/v10.0.0-cip3/metamask-key-tree-10.0.0-cip3.tgz",
     "@puppeteer/browsers@1.4.6": "patch:@puppeteer/browsers@npm%3A1.7.0#./.yarn/patches/@puppeteer-browsers-npm-1.7.0-203cb4f44b.patch",
     "@puppeteer/browsers@^1.6.0": "patch:@puppeteer/browsers@npm%3A1.7.0#./.yarn/patches/@puppeteer-browsers-npm-1.7.0-203cb4f44b.patch",
     "@types/glob@*": "patch:@types/glob@npm%3A7.1.4#./.yarn/patches/@types-glob-npm-7.1.4-d45247eaa2.patch",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DtqCkGevlAXjYPpejmh0PW3OXNVm4zYi/PHYVu1U+is=",
+    "shasum": "rUNoGs97cWa9CbN0/WT96iRAgiMrq2J1SJ65DH/I00w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lzjiI94y3QWSHvxvwWPJ3QiLoVpRoDK9aI0KfiFGaO0=",
+    "shasum": "06NuYU9MpCDFQStHo4CUM1hIHb8B2m7LGoaVPMs1NJ0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Af0qYFlaZB9ublbw/EdKs/zKfWsSXAG2Mi/XTRmAHOU=",
+    "shasum": "nYNwd+2UHs2GYyv6pDWVq9K091tIOLFHeGVR9wXVVCA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-controllers",
-  "version": "6.0.2",
+  "version": "6.0.2-cip3",
   "description": "Controllers for MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-execution-environments",
-  "version": "5.0.2",
+  "version": "5.0.2-cip3",
   "description": "Snap sandbox environments for executing SES javascript",
   "repository": {
     "type": "git",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-jest",
-  "version": "6.0.1",
+  "version": "6.0.1-cip3",
   "description": "A Jest preset for end-to-end testing MetaMask Snaps, including a Jest environment, and a set of Jest matchers.",
   "sideEffects": false,
   "exports": {

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-rpc-methods",
-  "version": "7.0.1",
+  "version": "7.0.1-cip3",
   "description": "MetaMask Snaps JSON-RPC method implementations.",
   "repository": {
     "type": "git",

--- a/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -137,5 +137,33 @@ describe('getBip32EntropyImplementation', () => {
         }
       `);
     });
+
+    it('derives a path using ed25519Bip32', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const getMnemonic = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+
+      expect(
+        // @ts-expect-error Missing other required properties.
+        await getBip32EntropyImplementation({ getUnlockPromise, getMnemonic })({
+          params: {
+            path: ['m', "1852'", "1815'", "0'", "0'", "1'"],
+            curve: 'ed25519Bip32',
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        {
+          "chainCode": "0x817a9b013e2eec99fb4f8ad02f9ce6a61bebf16f6d47ea1b1584ed20ffa5e247",
+          "curve": "ed25519Bip32",
+          "depth": 5,
+          "index": 2147483649,
+          "masterFingerprint": 1587894111,
+          "parentFingerprint": 1333559641,
+          "privateKey": "0x88dc4994979afd94803d0a46299e1322699e23f679b71e05a4775e3cf2bc734e90afc215bdccb8850061eb1e6cd22fce64a03c66f61168d260fadfb02d20d07f",
+          "publicKey": "0x82022f5895badf5c1083a74ea70885c1af18eaa844dabc83ae60db14188dd370",
+        }
+      `);
+    });
   });
 });

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -123,5 +123,27 @@ describe('getBip32PublicKeyImplementation', () => {
         `"0x022de17487a660993177ce2a85bb73b6cd9ad436184d57bdf5a93f5db430bea914"`,
       );
     });
+
+    it('derives the ed25519Bip32 public key from the path', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const getMnemonic = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+
+      expect(
+        await getBip32PublicKeyImplementation({
+          getUnlockPromise,
+          getMnemonic,
+          // @ts-expect-error Missing other required properties.
+        })({
+          params: {
+            path: ['m', "1852'", "1815'", "0'", "0'", "0'"],
+            curve: 'ed25519Bip32',
+          },
+        }),
+      ).toMatchInlineSnapshot(
+        `"0xca0ecffeb7926788f1ed8c023a24219859415f8c55f500abb32871085f05c10d"`,
+      );
+    });
   });
 });

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -53,7 +53,7 @@ type GetBip32PublicKeySpecification = ValidPermissionSpecification<{
 export const Bip32PublicKeyArgsStruct = bip32entropy(
   object({
     path: Bip32PathStruct,
-    curve: enums(['ed25519', 'secp256k1']),
+    curve: enums(['ed25519', 'secp256k1', 'ed25519Bip32']),
     compressed: optional(boolean()),
   }),
 );

--- a/packages/snaps-rpc-methods/src/utils.test.ts
+++ b/packages/snaps-rpc-methods/src/utils.test.ts
@@ -72,4 +72,25 @@ describe('getNode', () => {
       }
     `);
   });
+
+  it('returns an ed25519Bip32 node', async () => {
+    const node = await getNode({
+      curve: 'ed25519Bip32',
+      path: ['m', "1852'", "1815'"],
+      secretRecoveryPhrase: TEST_SECRET_RECOVERY_PHRASE_BYTES,
+    });
+
+    expect(node).toMatchInlineSnapshot(`
+      {
+        "chainCode": "0x4008460bcab45542b91b5d0c2815b3b2543432d18f4e61911c09197cb2c61333",
+        "curve": "ed25519Bip32",
+        "depth": 2,
+        "index": 2147485463,
+        "masterFingerprint": 1587894111,
+        "parentFingerprint": 3947345764,
+        "privateKey": "0x302f663588ebab9e2c357045bd141325c1639761d616080a3e2aa313e2bc734ef63612dba17778c957a321291c5e77e80ffb4fe233b491e931f9a1de7ae550e6",
+        "publicKey": "0x14029ae278dff12653d0dec3dc0d843c40cc5301c768806e3d112f22c9f3611f",
+      }
+    `);
+  });
 });

--- a/packages/snaps-rpc-methods/src/utils.ts
+++ b/packages/snaps-rpc-methods/src/utils.ts
@@ -2,6 +2,7 @@ import type {
   HardenedBIP32Node,
   BIP32Node,
   SLIP10PathNode,
+  CIP3PathNode,
 } from '@metamask/key-tree';
 import { SLIP10Node } from '@metamask/key-tree';
 import type { MagicValue } from '@metamask/snaps-utils';
@@ -165,17 +166,21 @@ export async function deriveEntropy({
  * @returns The path prefix, i.e., `secp256k1` or `ed25519`.
  */
 export function getPathPrefix(
-  curve: 'secp256k1' | 'ed25519',
-): 'bip32' | 'slip10' {
+  curve: 'secp256k1' | 'ed25519' | 'ed25519Bip32',
+): 'bip32' | 'slip10' | 'cip3' {
   if (curve === 'secp256k1') {
     return 'bip32';
+  }
+
+  if (curve === 'ed25519Bip32') {
+    return 'cip3';
   }
 
   return 'slip10';
 }
 
 type GetNodeArgs = {
-  curve: 'secp256k1' | 'ed25519';
+  curve: 'secp256k1' | 'ed25519' | 'ed25519Bip32';
   secretRecoveryPhrase: Uint8Array;
   path: string[];
 };
@@ -205,7 +210,8 @@ export async function getNode({
       secretRecoveryPhrase,
       ...(path.slice(1).map((index) => `${prefix}:${index}`) as
         | BIP32Node[]
-        | SLIP10PathNode[]),
+        | SLIP10PathNode[]
+        | CIP3PathNode[]),
     ],
   });
 }

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-sdk",
-  "version": "3.1.0",
+  "version": "3.1.0-cip3",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-sdk/src/types/permissions.ts
+++ b/packages/snaps-sdk/src/types/permissions.ts
@@ -10,7 +10,7 @@ export type Cronjob = {
 };
 
 export type Bip32Entropy = {
-  curve: 'secp256k1' | 'ed25519';
+  curve: 'secp256k1' | 'ed25519' | 'ed25519Bip32';
   path: string[];
 };
 

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-utils",
-  "version": "7.0.2",
+  "version": "7.0.2-cip3",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-utils/src/derivation-paths.ts
+++ b/packages/snaps-utils/src/derivation-paths.ts
@@ -145,6 +145,16 @@ export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
     curve: 'ed25519',
     name: 'Vega',
   },
+  {
+    path: ['m', `1852'`, `1815'`],
+    curve: 'ed25519Bip32',
+    name: 'Cardano',
+  },
+  {
+    path: ['m', `1694'`, `1815'`],
+    curve: 'ed25519Bip32',
+    name: 'Cardano-Voting',
+  },
 ];
 
 /**

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -111,7 +111,7 @@ export const bip32entropy = <
 export const Bip32EntropyStruct = bip32entropy(
   type({
     path: Bip32PathStruct,
-    curve: enums(['ed25519', 'secp256k1']),
+    curve: enums(['ed25519', 'secp256k1', 'ed25519Bip32']),
   }),
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3201,7 +3201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/tx@npm:^4.1.2, @ethereumjs/tx@npm:^4.2.0":
+"@ethereumjs/tx@npm:^4.2.0":
   version: 4.2.0
   resolution: "@ethereumjs/tx@npm:4.2.0"
   dependencies:
@@ -4901,17 +4901,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/key-tree@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@metamask/key-tree@npm:9.0.0"
+"@metamask/key-tree@https://github.com/nufi-official/metamask-key-tree/releases/download/v10.0.0-cip3/metamask-key-tree-10.0.0-cip3.tgz":
+  version: 10.0.0-cip3
+  resolution: "@metamask/key-tree@https://github.com/nufi-official/metamask-key-tree/releases/download/v10.0.0-cip3/metamask-key-tree-10.0.0-cip3.tgz"
   dependencies:
-    "@metamask/scure-bip39": ^2.1.0
-    "@metamask/utils": ^6.0.1
-    "@noble/ed25519": ^1.6.0
-    "@noble/hashes": ^1.0.0
-    "@noble/secp256k1": ^1.5.5
+    "@metamask/scure-bip39": ^2.1.1
+    "@metamask/utils": ^8.3.0
+    "@noble/curves": ^1.2.0
+    "@noble/hashes": ^1.3.2
     "@scure/base": ^1.0.0
-  checksum: 5c81f07351ca59b37570d52edcc80d60424630b2a8403ed7149c3343c264878ac5d3fc0584a61635ea7ddda4a789295ded1247846606dc529d8e2fd42f6fc61a
+  checksum: 58947686f0668614502c1e57454aecbbed13141ca8a0143824fcbfff62bdeaac301154203b2b3c32c2d7a2d7daf1dabda614d4b54cec77907a024daaa805da78
   languageName: node
   linkType: hard
 
@@ -5281,7 +5280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/scure-bip39@npm:^2.1.0":
+"@metamask/scure-bip39@npm:^2.1.1":
   version: 2.1.1
   resolution: "@metamask/scure-bip39@npm:2.1.1"
   dependencies:
@@ -6161,20 +6160,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/utils@npm:^6.0.1":
-  version: 6.2.0
-  resolution: "@metamask/utils@npm:6.2.0"
-  dependencies:
-    "@ethereumjs/tx": ^4.1.2
-    "@noble/hashes": ^1.3.1
-    "@types/debug": ^4.1.7
-    debug: ^4.3.4
-    semver: ^7.3.8
-    superstruct: ^1.0.3
-  checksum: 0bc675358ecc09b3bc04da613d73666295d7afa51ff6b8554801585966900b24b8545bd93b8b2e9a17db867ebe421fe884baf3558ec4ca3199fa65504f677c1b
-  languageName: node
-  linkType: hard
-
 "@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0, @metamask/utils@npm:^8.2.1, @metamask/utils@npm:^8.3.0":
   version: 8.3.0
   resolution: "@metamask/utils@npm:8.3.0"
@@ -6400,14 +6385,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.2, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.1, @noble/hashes@npm:~1.3.2":
+"@noble/hashes@npm:1.3.2, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.1, @noble/hashes@npm:~1.3.2":
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
   checksum: fe23536b436539d13f90e4b9be843cc63b1b17666a07634a2b1259dded6f490be3d050249e6af98076ea8f2ea0d56f578773c2197f2aa0eeaa5fba5bc18ba474
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:1.7.1, @noble/secp256k1@npm:^1.5.5, @noble/secp256k1@npm:^1.7.1":
+"@noble/secp256k1@npm:1.7.1, @noble/secp256k1@npm:^1.7.1":
   version: 1.7.1
   resolution: "@noble/secp256k1@npm:1.7.1"
   checksum: d2301f1f7690368d8409a3152450458f27e54df47e3f917292de3de82c298770890c2de7c967d237eff9c95b70af485389a9695f73eb05a43e2bd562d18b18cb


### PR DESCRIPTION
Changes:
 - resolution for @metamask/key-tree package with cip3
 - update versions of packages that are needed for snap or metamask extension, `cip3` suffix to signify they use updated `key-tree`, 
 - minor changes related to new derivation curve `ed25519Bip32` and new node `cip3`, mostly validation and types
 - add labels for cardano paths